### PR TITLE
feat: add employee model to timesheet model

### DIFF
--- a/src/calls/employee/models/employee.ts
+++ b/src/calls/employee/models/employee.ts
@@ -1,7 +1,7 @@
 import * as rt from 'runtypes';
 import { multipleValuesEnvelope } from '../../../utils';
 
-const employeeRt = rt.Record({
+export const employeeRt = rt.Record({
   id: rt.Number,
   version: rt.Number.nullable().optional(),
   firstName: rt.String,

--- a/src/calls/timesheet/models/timesheet.ts
+++ b/src/calls/timesheet/models/timesheet.ts
@@ -1,5 +1,6 @@
 import * as rt from 'runtypes';
 import { multipleValuesEnvelope, singleValueEnvelope } from '../../../utils';
+import { employeeRt } from '../../employee/employee';
 
 const timesheetRt = rt.Record({
   id: rt.Number,
@@ -19,9 +20,7 @@ const timesheetRt = rt.Record({
   date: rt.String,
   hours: rt.Number,
   chargeableHours: rt.Number.optional(),
-  employee: rt.Record({
-    id: rt.Number,
-  }),
+  employee: employeeRt,
   // timeClocks: rt.Array(rt.String),
   comment: rt.String.optional(),
   locked: rt.Boolean,


### PR DESCRIPTION
I need to access the `email` field on `timesheet.employee` and noticed that the employee field only contained `id`. 