### PR TITLE
feat: add reactivate subscription method

### DIFF
--- a/src/calls/event/event.ts
+++ b/src/calls/event/event.ts
@@ -4,6 +4,7 @@ import {
   createSubscriptionResponseRt,
   getSubscriptionResponseRt,
   listSubscriptionResponseRt,
+  reactivateSubscriptionResponseRt,
 } from './models/subscription';
 import { CreateSubscriptionInput, ListSubscriptionsInput } from './types';
 export * from './types';
@@ -30,7 +31,7 @@ export class TripletexEvent extends TripletexBase {
       .path(({ id }) => `/v2/event/subscription/${id}`)
       .method('put')
       .body(requestBody)
-      .parseJson(withRuntype(getSubscriptionResponseRt))
+      .parseJson(withRuntype(reactivateSubscriptionResponseRt))
       .build();
 
     return this.performRequest(sessionToken => call({ id, sessionToken }));

--- a/src/calls/event/event.ts
+++ b/src/calls/event/event.ts
@@ -21,6 +21,21 @@ export class TripletexEvent extends TripletexBase {
     return this.performRequest(sessionToken => call({ id, sessionToken }));
   }
 
+  reactivateSubscription(id: number) {
+    const requestBody = {
+      status: "ACTIVE",
+    }
+    const call = this.authenticatedCall()
+      .args<{ id: number }>()
+      .path(({ id }) => `/v2/event/subscription/${id}`)
+      .method('put')
+      .body(requestBody)
+      .parseJson(withRuntype(getSubscriptionResponseRt))
+      .build();
+
+    return this.performRequest(sessionToken => call({ id, sessionToken }));
+  }
+
   deleteSubscription(id: number) {
     const call = this.authenticatedCall() //
       .args<{ id: number }>()

--- a/src/calls/event/models/subscription.ts
+++ b/src/calls/event/models/subscription.ts
@@ -26,3 +26,4 @@ export type Subscription = rt.Static<typeof subscriptionRt>;
 export const listSubscriptionResponseRt = multipleValuesEnvelope(subscriptionRt);
 export const createSubscriptionResponseRt = singleValueEnvelope(subscriptionRt);
 export const getSubscriptionResponseRt = singleValueEnvelope(subscriptionRt);
+export const reactivateSubscriptionResponseRt = singleValueEnvelope(subscriptionRt);


### PR DESCRIPTION
according to the tripletex documentation for webhooks, it is possible for the subscription to get the status `DISABLED_TOO_MANY_ERRORS`. this can be reactivated by sending a PUT request on the subscription by id. Adding a `reactivateSubscription`allows for this put request.

documentation: https://developer.tripletex.no/docs/documentation/webhooks/
swagger: https://tripletex.no/v2-docs/#/event%2Fsubscription/EventSubscription_put